### PR TITLE
Update CSS for Research mode and support Multimarkdown table syntax

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10266,6 +10266,14 @@
         "js-yaml": "^3.8.1"
       }
     },
+    "markdown-it-multimd-table": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/markdown-it-multimd-table/-/markdown-it-multimd-table-3.2.3.tgz",
+      "integrity": "sha512-sL3qejhZtOZHIM8GG/OK1hoephLnqzMRrkVO5SUH23PXYrJkWleiNYBnEjRWPL2xd2oCqA+/PH4oQa8Gzqx4fA==",
+      "requires": {
+        "markdown-it": "^8.4.2"
+      }
+    },
     "markdown-it-named-headers": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/markdown-it-named-headers/-/markdown-it-named-headers-0.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "markdown-it-highlightjs": "^3.0.0",
     "markdown-it-katex": "^2.0.3",
     "markdown-it-meta": "0.0.1",
+    "markdown-it-multimd-table": "^3.2.3",
     "markdown-it-named-headers": "^0.0.4",
     "raw-loader": "^1.0.0",
     "text-statistics": "^0.1.1",

--- a/public/css/research.css
+++ b/public/css/research.css
@@ -486,6 +486,7 @@ markdown-body code {
 .markdown-body .info-block {
   background-color: rgba(27, 31, 35, 0.05);
   font-family: "Lato", sans-serif;
+  font-size: 16px;
   margin: 16px 0px;
   padding: 24px 48px 16px;
 }

--- a/public/css/research.css
+++ b/public/css/research.css
@@ -460,10 +460,10 @@ markdown-body code {
 
 /* blockquote */
 .markdown-body blockquote {
-  border-left: 0.25em solid #dfe2e5;
-  font-family: "Lato", sans-serif;
-  color: #6a737d;
-  padding: 0 1em;
+  background-color: #ebf6ff;
+  border-left: 0.25em solid #466c8c;
+  color: #466c8c;
+  padding: 1em 2em;
   margin: 2em 0;
 }
 

--- a/public/css/research.css
+++ b/public/css/research.css
@@ -481,3 +481,19 @@ markdown-body code {
 .markdown-body blockquote > :last-child {
   margin-bottom: 0;
 }
+
+/* information block */
+.markdown-body .info-block {
+  background-color: rgba(27, 31, 35, 0.05);
+  font-family: "Lato", sans-serif;
+  margin: 16px 0px;
+  padding: 24px 48px 16px;
+}
+.markdown-body .info-block-title {
+  font-weight: bold;
+  padding-bottom: 16px;
+  text-transform: uppercase;
+}
+.markdown-body .info-block a {
+  color: #166cc0 !important;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -38,6 +38,10 @@
       href="https://fonts.googleapis.com/css?family=Montserrat:400,700|Open+Sans:300,400,700,800"
       rel="stylesheet"
     />
+    <link
+      href="https://fonts.googleapis.com/css?family=Lato:300,400&display=swap"
+      rel="stylesheet"
+    />
     <script src="https://unpkg.com/turndown/dist/turndown.js"></script>
     <script src="https://unpkg.com/turndown-plugin-gfm/dist/turndown-plugin-gfm.js"></script>
   </head>

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -29,6 +29,10 @@ const config = {
     typographer: false,
     quotes: "“”‘’"
   },
+  markdownItMultimdTableOptions: {
+    enableMultilineRows: true,
+    enableRowspan: true
+  },
   /**
    *
    *

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -153,7 +153,8 @@ let md = require("markdown-it")(config.markdownItOptions)
   .use(require("markdown-it-attrs"))
   .use(require("@/markdown-it-meta-fork"))
   .use(require("markdown-it-container"))
-  .use(require("markdown-it-highlightjs"));
+  .use(require("markdown-it-highlightjs"))
+  .use(require("markdown-it-multimd-table"), config.markdownItMultimdTableOptions);
 
 require("codemirror/mode/markdown/markdown");
 require("codemirror/addon/edit/closebrackets");


### PR DESCRIPTION
Changes:
* add [`markdown-it-multimd-table`](https://github.com/RedBug312/markdown-it-multimd-table) plugin to support complex table
* update CSS for Research mode to match the Research Hub style
* add font Lato for Research mode style