### PR TITLE
Support math expressions using Katex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9822,14 +9822,6 @@
         "verror": "1.10.0"
       }
     },
-    "katex": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.6.0.tgz",
-      "integrity": "sha1-EkGOCRIcBckgQbazuftrqyE8tvM=",
-      "requires": {
-        "match-at": "^0.1.0"
-      }
-    },
     "killable": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/killable/-/killable-1.0.1.tgz",
@@ -10250,14 +10242,6 @@
         "lodash.flow": "^3.1.0"
       }
     },
-    "markdown-it-katex": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/markdown-it-katex/-/markdown-it-katex-2.0.3.tgz",
-      "integrity": "sha1-17hqGuoLnWSW+rTnkZoY/e9YnDk=",
-      "requires": {
-        "katex": "^0.6.0"
-      }
-    },
     "markdown-it-meta": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/markdown-it-meta/-/markdown-it-meta-0.0.1.tgz",
@@ -10281,11 +10265,6 @@
       "requires": {
         "string": "^3.0.1"
       }
-    },
-    "match-at": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/match-at/-/match-at-0.1.1.tgz",
-      "integrity": "sha512-h4Yd392z9mST+dzc+yjuybOGFNOZjmXIPKWjxBd1Bb23r4SmDOsk2NYCU2BMUBGbSpZqwVsZYNq26QS3xfaT3Q=="
     },
     "math-random": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "markdown-it-emoji": "^1.4.0",
     "markdown-it-footnote": "^3.0.1",
     "markdown-it-highlightjs": "^3.0.0",
-    "markdown-it-katex": "^2.0.3",
     "markdown-it-meta": "0.0.1",
     "markdown-it-multimd-table": "^3.2.3",
     "markdown-it-named-headers": "^0.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -44,6 +44,16 @@
     />
     <script src="https://unpkg.com/turndown/dist/turndown.js"></script>
     <script src="https://unpkg.com/turndown-plugin-gfm/dist/turndown-plugin-gfm.js"></script>
+    <link
+      href="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.css"
+      rel="stylesheet"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/katex@0.10.2/dist/katex.min.js"></script>
+    <link
+      href="https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.css"
+      rel="stylesheet"
+    />
+    <script src="https://gitcdn.xyz/cdn/goessner/markdown-it-texmath/master/texmath.js"></script>
   </head>
   <body>
     <noscript>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -154,7 +154,12 @@ let md = require("markdown-it")(config.markdownItOptions)
   .use(require("@/markdown-it-meta-fork"))
   .use(require("markdown-it-container"))
   .use(require("markdown-it-highlightjs"))
-  .use(require("markdown-it-multimd-table"), config.markdownItMultimdTableOptions);
+  .use(
+    require("markdown-it-multimd-table"),
+    config.markdownItMultimdTableOptions
+  )
+  // eslint-disable-next-line no-undef
+  .use(texmath.use(katex));
 
 require("codemirror/mode/markdown/markdown");
 require("codemirror/addon/edit/closebrackets");


### PR DESCRIPTION
Changes:

*  use `katex` with [`markdown-it-texmath`](https://github.com/goessner/markdown-it-texmath) plugin, both loaded via CDN
*  uninstall now redundant & unnecessary `markdown-it-katex` plugin
